### PR TITLE
New feature: keep set quality as max quality

### DIFF
--- a/pages/options.html
+++ b/pages/options.html
@@ -3,7 +3,11 @@
 
 <body>
 
-<input type="checkbox" id="pause"/> Pause the video at the start.
+<h1>Your Quality for YouTube<sup>TM</sup></h1>
+
+<input type="checkbox" id="pause"/> <label for="pause">Pause the video at the start.</label><br />
+
+<input type="checkbox" id="keepquality" /> <label for="keepquality">Re-set quality on (automatic) increase.</label>
 
 </body>
 <script src="options.js"></script>

--- a/pages/options.js
+++ b/pages/options.js
@@ -4,6 +4,11 @@ function save_options() {
 	chrome.extension.getBackgroundPage().pause = true;
   else
 	chrome.extension.getBackgroundPage().pause = false;
+  localStorage['ytKeepQuality'] = document.getElementById("keepquality").checked;
+  if(localStorage['ytKeepQuality'] === "true")
+	chrome.extension.getBackgroundPage().keepquality = true;
+  else
+	chrome.extension.getBackgroundPage().keepquality = false;
 }
 
 function restore_options() {
@@ -12,6 +17,12 @@ function restore_options() {
 	document.getElementById("pause").checked = true;
   else
 	document.getElementById("pause").checked = false;
+  var keepquality = localStorage["ytKeepQuality"];
+  if(keepquality === "true")
+	document.getElementById("keepquality").checked = true;
+  else
+	document.getElementById("keepquality").checked = false;
 }
 document.addEventListener('DOMContentLoaded', restore_options);
 document.querySelector('#pause').addEventListener('change', save_options);
+document.querySelector('#keepquality').addEventListener('change', save_options);

--- a/scripts/background.js
+++ b/scripts/background.js
@@ -1,9 +1,14 @@
 var res = localStorage['ytQuality'];
 var pause = false;
+var keepquality = false;
+
 if(localStorage['ytPause'] === "true")
 		pause = true;
+if(localStorage['ytKeepQuality'])
+		keepquality = true;
 if(isNaN(res) || res > 8 || res < 0)
 		res = 4;
+
 chrome.extension.onRequest.addListener(function(request, sender, sendResponse) {
 		if (request.method === "getStatus"){
 				if(res < 8 && res >=0)
@@ -13,6 +18,8 @@ chrome.extension.onRequest.addListener(function(request, sender, sendResponse) {
 		}
 		else if (request.method === "getPause")
 				sendResponse({status: pause});
+		else if (request.method === "getKeepQuality")
+				sendResponse({status: keepquality});
 		else
 				sendResponse({});
 });

--- a/scripts/yt.js
+++ b/scripts/yt.js
@@ -1,5 +1,6 @@
 var quality = 0;
 var pause = false;
+var keepquality = false;
 
 function injectCode(){
 		var inj0 = document.createElement('script');
@@ -13,7 +14,7 @@ function injectCode(){
 		
 		inj1.innerHTML =
 				["function onYouTubePlayerReady(player){",
-				 "		setTimeout(function(){ytPlayerHook(player," + quality + "," + pause + ");},10);",
+				 "		setTimeout(function(){ytPlayerHook(player," + quality + "," + pause + "," + keepquality + ");},10);",
 				 "}"].join('\n');
 		docFrag.appendChild(inj0);
 		docFrag.appendChild(inj1);
@@ -26,7 +27,10 @@ chrome.extension.sendRequest({method: "getStatus"}, function(response) {
 		quality = response.status;
 		chrome.extension.sendRequest({method: "getPause"}, function(response) {
 				pause = response.status;
-				injectCode();
+				chrome.extension.sendRequest({method: "getKeepQuality"}, function(response) {
+						keepquality = response.status;
+						injectCode();
+				});
 		});
 });
 


### PR DESCRIPTION
This patch provides a feature to prevent YouTube (and the user!) from increasing the quality to a value higher than the chosen quality while playback.