### PR TITLE
Feature to save internet Bandwidth added

### DIFF
--- a/pages/options.html
+++ b/pages/options.html
@@ -5,6 +5,7 @@
 
 <input type="checkbox" id="highpref"/> High video quality is preferable.<BR/>
 <input type="checkbox" id="pause"/> Pause the video at the start.<BR/>
+<input type="checkbox" id="smart_save">Switch on "Smart Save" to save internet Bandwidth.<br/>
 
 <hr>
 Default speed

--- a/pages/options.js
+++ b/pages/options.js
@@ -1,15 +1,23 @@
 function save_options() {
+
   localStorage['ytHighPref'] = document.getElementById("highpref").checked;
   if(localStorage['ytHighPref'] === "true")
-	chrome.extension.getBackgroundPage().highpref = true;
+  chrome.extension.getBackgroundPage().highpref = true;
   else
-	chrome.extension.getBackgroundPage().highpref = false;
+  chrome.extension.getBackgroundPage().highpref = false;
+
   localStorage['ytPause'] = document.getElementById("pause").checked;
   if(localStorage['ytPause'] === "true")
-	chrome.extension.getBackgroundPage().pause = true;
+  chrome.extension.getBackgroundPage().pause = true;
   else
-	chrome.extension.getBackgroundPage().pause = false;
-	
+  chrome.extension.getBackgroundPage().pause = false;
+
+  localStorage['ytSmartSave'] = document.getElementById("smart_save").checked;
+  if(localStorage['ytSmartSave'] === "true")
+  chrome.extension.getBackgroundPage().smart_save = true;
+  else
+  chrome.extension.getBackgroundPage().smart_save = false;
+
   localStorage['ytSpeed'] = document.getElementById('speed').value;
   chrome.extension.getBackgroundPage().speed = localStorage['ytSpeed'];
 }
@@ -17,19 +25,28 @@ function save_options() {
 function restore_options() {
   var speed = localStorage['ytSpeed'];
   document.getElementById('speed').value = speed;
+
   var highpref = localStorage["ytHighPref"];
   if(highpref === "true")
-	document.getElementById("highpref").checked = true;
+  document.getElementById("highpref").checked = true;
   else
-	document.getElementById("highpref").checked = false;
+  document.getElementById("highpref").checked = false;
+
   var pause = localStorage["ytPause"];
   if(pause === "true")
-	document.getElementById("pause").checked = true;
+  document.getElementById("pause").checked = true;
   else
-	document.getElementById("pause").checked = false;
+  document.getElementById("pause").checked = false;
+
+  var smart_save = localStorage["ytSmartSave"];
+  if(smart_save === "true")
+  document.getElementById("smart_save").checked = true;
+  else
+  document.getElementById("smart_save").checked = false;
+
 }
 document.addEventListener('DOMContentLoaded', restore_options);
 document.querySelector('#highpref').addEventListener('change', save_options);
 document.querySelector('#pause').addEventListener('change', save_options);
 document.querySelector('#speed').addEventListener('change', save_options);
-
+document.querySelector('#smart_save').addEventListener('change', save_options);

--- a/scripts/background.js
+++ b/scripts/background.js
@@ -3,6 +3,7 @@ var speed = localStorage['ytSpeed'];
 var highpref = false;
 var pause = false;
 
+
 if(localStorage['ytHighPref'] === "true")
 		highpref = true;
 if(localStorage['ytPause'] === "true")

--- a/scripts/background.js
+++ b/scripts/background.js
@@ -1,5 +1,8 @@
 var res = localStorage['ytQuality'];
 var speed = localStorage['ytSpeed'];
+if(isNaN(speed))
+	speed = 1;
+var smart_save = localStorage['ytSmartSave'];
 var highpref = false;
 var pause = false;
 
@@ -23,6 +26,8 @@ chrome.extension.onRequest.addListener(function(request, sender, sendResponse) {
 				sendResponse({status: pause});
 		else if (request.method === "getSpeed")
 				sendResponse({status: speed});
+		else if (request.method === "getSmartSave")
+		 		sendResponse({status: smart_save});
 		else
 				sendResponse({});
 });

--- a/scripts/utils.js
+++ b/scripts/utils.js
@@ -4,6 +4,7 @@ var sytqQuality = 2;
 var sytqHighPref = false;
 var sytqPause = false;
 var sytqPlayer;
+var sytqSmartSave = true;
 var sytqSpeed = 1;
 
 var hooked = false;
@@ -101,19 +102,20 @@ function ytPlayerSetHooks(){
 		return;
 	}
 	sytqPlayer.addEventListener("onStateChange", ytPlayerChange);
-	autotoggle();	
+	autotoggle();
 	changeQuality();
 }
 
-function ytPlayerHook(player, speed, quality, highpref, pause){
+function ytPlayerHook(player, speed, quality, highpref, pause, smart_save){
 	if(hooked || typeof player !== 'object')
 		return;
-	//console.log('ytPlayerHook');
+	console.log('ytPlayerHook');
 	hooked = true;
 	sytqSpeed = speed;
 	sytqQuality = quality;
 	sytqHighPref = highpref;
 	sytqPause = pause;
+	sytqSmartSave = smart_save;
 	sytqPlayer = player;
 	ytPlayerSetHooks();
 }
@@ -133,16 +135,19 @@ function autotoggle(){
   min = count[count.length - 2];
 
   window.addEventListener('focus', function() {
-    sytqPlayer.setPlaybackQuality(current);
-    console.log(current);
+		console.log('focus');
+		if( sytqSmartSave === true ) {
+    	sytqPlayer.setPlaybackQuality(current);
+    	console.log(current);
+		}
   });
 
   window.addEventListener('blur', function() {
-    current = sytqPlayer.getPlaybackQuality();
-    sytqPlayer.setPlaybackQuality(min);
-    console.log(min);
-  });
+		console.log('blur');
+		if( sytqSmartSave === true ) {
+    	current = sytqPlayer.getPlaybackQuality();
+    	sytqPlayer.setPlaybackQuality(min);
+    	console.log(min);
+		}
+	});
 }
-
-
-

--- a/scripts/utils.js
+++ b/scripts/utils.js
@@ -101,6 +101,7 @@ function ytPlayerSetHooks(){
 		return;
 	}
 	sytqPlayer.addEventListener("onStateChange", ytPlayerChange);
+	autotoggle();	
 	changeQuality();
 }
 
@@ -116,3 +117,32 @@ function ytPlayerHook(player, speed, quality, highpref, pause){
 	sytqPlayer = player;
 	ytPlayerSetHooks();
 }
+
+var min;
+var current;
+var count;
+
+function autotoggle(){
+  if(typeof sytqPlayer.getPlayerState === 'undefined' || sytqPlayer.getPlayerState() < 0 ){
+    setTimeout( autotoggle ,200);
+    return;
+  }
+
+  current = sytqPlayer.getPlaybackQuality();
+  count = sytqPlayer.getAvailableQualityLevels();
+  min = count[count.length - 2];
+
+  window.addEventListener('focus', function() {
+    sytqPlayer.setPlaybackQuality(current);
+    console.log(current);
+  });
+
+  window.addEventListener('blur', function() {
+    current = sytqPlayer.getPlaybackQuality();
+    sytqPlayer.setPlaybackQuality(min);
+    console.log(min);
+  });
+}
+
+
+

--- a/scripts/yt.js
+++ b/scripts/yt.js
@@ -1,6 +1,8 @@
 var quality = 0;
+var speed = 1;
 var highpref = false;
 var pause = false;
+var smart_save = true;
 
 function injectCode(){
 		var inj0 = document.createElement('script');
@@ -11,27 +13,31 @@ function injectCode(){
 		inj0.onload = function() {
 			this.parentNode.removeChild(this);
 		};
-		
+
 		inj1.innerHTML =
 				["function onYouTubePlayerReady(player){",
-				 "		setTimeout(function(){ytPlayerHook(player, " + speed + ", " + quality + ", " + highpref + ", " + pause + ");},10);",
+				 "		setTimeout(function(){ytPlayerHook(player, 1, " + quality + ", " + highpref + ", " + pause + ", " + smart_save + ");},10);",
 				 "}"].join('\n');
+				 // on line 19, 1 is the value for speed.
 		docFrag.appendChild(inj0);
 		docFrag.appendChild(inj1);
-		
+
 		(document.head||document.documentElement).appendChild(docFrag);
 		inj1.parentNode.removeChild(inj1);
 }
 
 chrome.extension.sendRequest({method: "getStatus"}, function(response) {
-		quality = response.status;
+	quality = response.status;
 		chrome.extension.sendRequest({method: "getHighPref"}, function(response) {
 			highpref = response.status;
-			chrome.extension.sendRequest({method: "getPause"}, function(response) {
-                pause = response.status;
-                chrome.extension.sendRequest({method: "getSpeed"}, function(response) {
-                speed = response.status;
-                    injectCode();
+				chrome.extension.sendRequest({method: "getPause"}, function(response) {
+        	pause = response.status;
+            chrome.extension.sendRequest({method: "getSpeed"}, function(response) {
+              speed = response.status;
+            		chrome.extension.sendRequest({method: "getSmartSave"}, function(response) {
+									smart_save = response.status;
+							    injectCode();
+				});
 			});
 		});
 	});


### PR DESCRIPTION
Other than videos, YouTube is also very popular for streaming music (videos). 
Generally, people put on music in the  background, while they do their work not realizing that it is unnecessarily eating up a lot of there internet bandwidth. The quality here makes a lot of difference.
 
Eg. On Netflix. 
Low uses up to 0.3 GB (or 300 MB) per hour of streaming, while High uses up to 3 GB per hour. 
10X difference.

![image](https://cloud.githubusercontent.com/assets/15344309/16932648/59885952-4d65-11e6-9604-786040537813.png)


So, to tackle this i have added an auto-toggle feature. 
This feature will see if the tab is active or not, and accordingly toggle between the lowest possible quality and the quality set by the user.
## Giving the user a normal YouTube experience while saving his internet bandwidth.
